### PR TITLE
fixed missing version specifiers for py27

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 453e252525005b4c22dc654c0379227d516bf9364cce46184b580684cb50ad40
 
 build:
-  number: 1000
+  number: 1
   entry_points:
     - cwltool=cwltool.main:run
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
@@ -36,8 +36,8 @@ requirements:
     - shellescape >=3.4.1
     - six >=1.9.0
     - typing_extensions
-    - pathlib2  # [py27]
-    - typing  # [py27]
+    - pathlib2 ==2.3.2  # [py27]
+    - typing >=3.5.3  # [py27]
     - subprocess32  # [not win and py27]
 
 test:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Adds version dependencies for two py2 dependencies I forgot in the initial recipe.
